### PR TITLE
Fixed settings validator to ignore ipboard validating baseURL, clientID, and clientSecret when enable flag is false.

### DIFF
--- a/server/config/settings-validate.js
+++ b/server/config/settings-validate.js
@@ -326,7 +326,7 @@ module.exports = {
 				}
 			},
 
-			defaultPlan: function(defaultPlan, settings) {
+			defaultPlan: function(defaultPlan, setting, settings) {
 				/* istanbul ignore if */
 				if (!settings.vpdb.quota.plans[defaultPlan]) {
 					return 'Default plan must exist in the "vpdb.quota.plans" setting.';
@@ -391,9 +391,9 @@ module.exports = {
 					return 'Enabled flag must be either true or false';
 				}
 			},
-			options: function(opt, settings) {
+			options: function(opt, setting) {
 				/* istanbul ignore if */
-				if (!settings.vpdb.pusher || !settings.vpdb.pusher.enabled) {
+				if (!setting.enabled) {
 					return;
 				}
 				/* istanbul ignore if */
@@ -423,9 +423,9 @@ module.exports = {
 				/**
 				 * The client ID of the generated application.
 				 */
-				clientID: function(id, settings) {
+				clientID: function(id, setting) {
 					/* istanbul ignore if */
-					if (!settings.vpdb.passport.google.enabled) {
+					if (!setting.enabled) {
 						return;
 					}
 					/* istanbul ignore if */
@@ -441,9 +441,9 @@ module.exports = {
 				/**
 				 * The client secret of the generated application.
 				 */
-				clientSecret: function(secret, settings) {
+				clientSecret: function(secret, setting) {
 					/* istanbul ignore if */
-					if (!settings.vpdb.passport.google.enabled) {
+					if (!setting.enabled) {
 						return;
 					}
 					/* istanbul ignore if */
@@ -476,9 +476,9 @@ module.exports = {
 				/**
 				 * The client ID of the generated application.
 				 */
-				clientID: function(id, settings) {
+				clientID: function(id, setting) {
 					/* istanbul ignore if */
-					if (!settings.vpdb.passport.github.enabled) {
+					if (!setting.enabled) {
 						return;
 					}
 					/* istanbul ignore if */
@@ -494,9 +494,9 @@ module.exports = {
 				/**
 				 * The client secret of the generated application.
 				 */
-				clientSecret: function(secret, settings) {
+				clientSecret: function(secret, setting) {
 					/* istanbul ignore if */
-					if (!settings.vpdb.passport.github.enabled) {
+					if (!setting.enabled) {
 						return;
 					}
 					/* istanbul ignore if */
@@ -529,7 +529,11 @@ module.exports = {
 				/**
 				 * Must contain only letters from a-z (no spaces or special chars).
 				 */
-				id: function(id) {
+				id: function(id, setting) {
+					/* istanbul ignore if */
+					if (!setting.enabled) {
+						return;
+					}
 					/* istanbul ignore if */
 					if (!/^[a-z0-9]+$/.test(id)) {
 						return 'ID must be alphanumeric';
@@ -539,7 +543,11 @@ module.exports = {
 				/**
 				 * Index file of the forum.
 				 */
-				baseURL: function(url) {
+				baseURL: function(url, setting) {
+					/* istanbul ignore if */
+					if (!setting.enabled) {
+						return;
+					}
 					var urlErr = checkUrl(url);
 					/* istanbul ignore if */
 					if (urlErr) {
@@ -554,7 +562,11 @@ module.exports = {
 				/**
 				 * The client ID of the generated application.
 				 */
-				clientID: function(id) {
+				clientID: function(id, setting) {
+					/* istanbul ignore if */
+					if (!setting.enabled) {
+						return;
+					}
 					/* istanbul ignore if */
 					if (id.length === 0) {
 						return 'Your client ID must be longer than 0 characters';
@@ -568,7 +580,11 @@ module.exports = {
 				/**
 				 * The client secret of the generated application.
 				 */
-				clientSecret: function(secret) {
+				clientSecret: function(secret, setting) {
+					/* istanbul ignore if */
+					if (!setting.enabled) {
+						return;
+					}
 					/* istanbul ignore if */
 					if (secret.length === 0) {
 						return 'Your client secret must be longer than 0 characters';

--- a/server/modules/settings.js
+++ b/server/modules/settings.js
@@ -79,7 +79,7 @@ Settings.prototype.validate = function() {
 						logger.error('[settings] %s [KO]: Setting is missing.', p);
 						success = false;
 					} else {
-						validationError = validation[s](setting[s], settings);
+						validationError = validation[s](setting[s], setting, settings);
 						if (!validationError) {
 							logger.info('[settings] %s [OK]', p);
 						} else {


### PR DESCRIPTION
In addition to passing in settings, pass in parent setting node, for quick access to enable flag. (Helpful since ipboard settings is an array.)