### PR TITLE
Add command line argument --ipaddress to grunt serve. Useful to bind server to 0.0.0.0 and be accessible from other computers.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -305,6 +305,7 @@ function setEnv(grunt) {
 
 function env(grunt, config, more) {
 	return _.extend({
+		IPADDRESS: grunt.option('ipaddress') || process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1',
 		PORT: grunt.option('port') || process.env.PORT || config.vpdb.webapp.port || 3000,
 		HTTP_SCHEME: config.vpdb.webapp.protocol,
 		AUTH_HEADER: config.vpdb.authorizationHeader

--- a/server/express.js
+++ b/server/express.js
@@ -49,12 +49,17 @@ exports.configure = function(app, raygunClient) {
 	logger.info('[express] Setting up Express for running %s in %s mode.', runningLocal ? 'locally' : 'remotely', runningDev ? 'development' : 'production');
 
 	/* istanbul ignore if  */
+	if (!process.env.IPADDRESS) {
+		throw new Error('Environment variable `IPADDRESS` not found, server cannot start on unknown ip address.');
+	}
+	
+	/* istanbul ignore if  */
 	if (!process.env.PORT) {
 		throw new Error('Environment variable `PORT` not found, server cannot start on unknown port.');
 	}
 
+	app.set('ipaddress', process.env.IPADDRESS);
 	app.set('port', process.env.PORT);
-	app.set('ipaddress', process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1');
 	app.set('views', path.resolve(__dirname, '../client/app'));
 	app.set('view engine', 'jade');
 	app.set('json spaces', "\t");


### PR DESCRIPTION
My RPI is headless so I can't access node-vpdb when bound to 127.0.0.1.

grunt serve --ipaddress=0.0.0.0